### PR TITLE
Bump streamlit-shap version from 0.0.3 to 0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ catboost==1.0.4
 pandas==1.4.0
 shap==0.40.0
 streamlit==1.4.0
-git+https://github.com/snehankekre/streamlit-shap.git@v0.0.3
+git+https://github.com/snehankekre/streamlit-shap.git@v0.0.4#egg=streamlit-shap


### PR DESCRIPTION
Update streamlit-shap to 0.0.4 to fix issue with colorbars and axis labels.