### PR TITLE
Bump streamlit-shap from 0.0.4 to 1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 catboost==1.0.4
 pandas==1.4.0
 shap==0.40.0
-streamlit==1.4.0
-git+https://github.com/snehankekre/streamlit-shap.git@v0.0.4#egg=streamlit-shap
+streamlit==1.7.0
+streamlit-shap==1.0.1


### PR DESCRIPTION
- Bump `streamlit-shap` from 0.0.4 to 1.0.1
- Bump `streamlit from` 1.4.0 to 1.7.0